### PR TITLE
Fix login screen UI overlap issue

### DIFF
--- a/src/setup/campaignSetup.js
+++ b/src/setup/campaignSetup.js
@@ -41,6 +41,7 @@ function campaignButtonsSetup() {
         btn.mousePressed(() => campaignButtonsFunction(i));
         campaignLevelButtons.push(btn);
     }
+    campaignButtonsDisplay(false);
 }
 
 // Show/hide campaign level buttons and display star ratings

--- a/src/setup/campaignSetup.js
+++ b/src/setup/campaignSetup.js
@@ -41,6 +41,8 @@ function campaignButtonsSetup() {
         btn.mousePressed(() => campaignButtonsFunction(i));
         campaignLevelButtons.push(btn);
     }
+    // Hide campaign level buttons by default
+    campaignButtonsDisplay(false);
 }
 
 // Show/hide campaign level buttons and display star ratings

--- a/src/setup/campaignSetup.js
+++ b/src/setup/campaignSetup.js
@@ -41,8 +41,6 @@ function campaignButtonsSetup() {
         btn.mousePressed(() => campaignButtonsFunction(i));
         campaignLevelButtons.push(btn);
     }
-    // Hide campaign level buttons by default
-    campaignButtonsDisplay(false);
 }
 
 // Show/hide campaign level buttons and display star ratings

--- a/src/setup/gameSetup.js
+++ b/src/setup/gameSetup.js
@@ -271,6 +271,8 @@ function mapButtonsSetup() {
   gulfwarMapButton.position(1200, 550);
   gulfwarMapButton.class("mainMenuButtonClass");
   gulfwarMapButton.mousePressed(gulfwarMapButtonFunction);
+
+  mapButtonsDisplay(false);
 }
 
 // Toggles the map selection buttons on and off depending on the input.

--- a/src/setup/gameSetup.js
+++ b/src/setup/gameSetup.js
@@ -271,9 +271,6 @@ function mapButtonsSetup() {
   gulfwarMapButton.position(1200, 550);
   gulfwarMapButton.class("mainMenuButtonClass");
   gulfwarMapButton.mousePressed(gulfwarMapButtonFunction);
-
-  // Hide map-selection buttons by default
-  mapButtonsDisplay(false);
 }
 
 // Toggles the map selection buttons on and off depending on the input.

--- a/src/setup/gameSetup.js
+++ b/src/setup/gameSetup.js
@@ -271,6 +271,9 @@ function mapButtonsSetup() {
   gulfwarMapButton.position(1200, 550);
   gulfwarMapButton.class("mainMenuButtonClass");
   gulfwarMapButton.mousePressed(gulfwarMapButtonFunction);
+
+  // Hide map-selection buttons by default
+  mapButtonsDisplay(false);
 }
 
 // Toggles the map selection buttons on and off depending on the input.

--- a/src/setup/menuSetup.js
+++ b/src/setup/menuSetup.js
@@ -49,6 +49,9 @@ function menuButtonsSetup() {
     settingsButton.position(740, 625);
     settingsButton.class("mainMenuButtonClass");
     settingsButton.mousePressed(settingsButtonFunction);
+
+    mainMenuButtonsDisplay(false);
+    returnToMenuButtonDisplay(false);
 }
 
 // Shows or hides the return to menu button depending on the input

--- a/src/setup/menuSetup.js
+++ b/src/setup/menuSetup.js
@@ -49,6 +49,10 @@ function menuButtonsSetup() {
     settingsButton.position(740, 625);
     settingsButton.class("mainMenuButtonClass");
     settingsButton.mousePressed(settingsButtonFunction);
+
+    // Hide menu DOM by default
+    mainMenuButtonsDisplay(false);
+    returnToMenuButtonDisplay(false);
 }
 
 // Shows or hides the return to menu button depending on the input

--- a/src/setup/menuSetup.js
+++ b/src/setup/menuSetup.js
@@ -49,10 +49,6 @@ function menuButtonsSetup() {
     settingsButton.position(740, 625);
     settingsButton.class("mainMenuButtonClass");
     settingsButton.mousePressed(settingsButtonFunction);
-
-    // Hide menu DOM by default
-    mainMenuButtonsDisplay(false);
-    returnToMenuButtonDisplay(false);
 }
 
 // Shows or hides the return to menu button depending on the input

--- a/src/setup/skillTreeSetup.js
+++ b/src/setup/skillTreeSetup.js
@@ -37,6 +37,9 @@ function skillTreeButtonsSetup() {
     specialAbilityUpgradeButton.position(740, 625);
     specialAbilityUpgradeButton.class("skillTreeButtonClass");
     specialAbilityUpgradeButton.mousePressed(() => skillTreeButtonsFunction(specialAbilityUpgrade, 5));
+
+    // Hide skill-tree UI by default
+    skillTreeButtonsDisplay(false);
 }
 
 // Shows or hides the skill tree buttons depending on the input.

--- a/src/setup/skillTreeSetup.js
+++ b/src/setup/skillTreeSetup.js
@@ -37,9 +37,6 @@ function skillTreeButtonsSetup() {
     specialAbilityUpgradeButton.position(740, 625);
     specialAbilityUpgradeButton.class("skillTreeButtonClass");
     specialAbilityUpgradeButton.mousePressed(() => skillTreeButtonsFunction(specialAbilityUpgrade, 5));
-
-    // Hide skill-tree UI by default
-    skillTreeButtonsDisplay(false);
 }
 
 // Shows or hides the skill tree buttons depending on the input.

--- a/src/setup/skillTreeSetup.js
+++ b/src/setup/skillTreeSetup.js
@@ -37,6 +37,8 @@ function skillTreeButtonsSetup() {
     specialAbilityUpgradeButton.position(740, 625);
     specialAbilityUpgradeButton.class("skillTreeButtonClass");
     specialAbilityUpgradeButton.mousePressed(() => skillTreeButtonsFunction(specialAbilityUpgrade, 5));
+
+    skillTreeButtonsDisplay(false);
 }
 
 // Shows or hides the skill tree buttons depending on the input.

--- a/src/setup/specialAbilitySetup.js
+++ b/src/setup/specialAbilitySetup.js
@@ -28,6 +28,7 @@ function specialAbilityButtonSetup() {
     specialAbilityButton.position(1750, 780);
     specialAbilityButton.class("towerRangeSpecialAbility");
     specialAbilityButton.mousePressed(() => specialAbilityButtonFunction(chosenMapInt));
+    specialAbilityButton.hide();
 }
 
 // Shows or hides the special ability buttons depending on the input.

--- a/src/setup/specialAbilitySetup.js
+++ b/src/setup/specialAbilitySetup.js
@@ -28,8 +28,6 @@ function specialAbilityButtonSetup() {
     specialAbilityButton.position(1750, 780);
     specialAbilityButton.class("towerRangeSpecialAbility");
     specialAbilityButton.mousePressed(() => specialAbilityButtonFunction(chosenMapInt));
-    // Hide special-ability button by default
-    specialAbilityButton.hide();
 }
 
 // Shows or hides the special ability buttons depending on the input.

--- a/src/setup/specialAbilitySetup.js
+++ b/src/setup/specialAbilitySetup.js
@@ -28,6 +28,8 @@ function specialAbilityButtonSetup() {
     specialAbilityButton.position(1750, 780);
     specialAbilityButton.class("towerRangeSpecialAbility");
     specialAbilityButton.mousePressed(() => specialAbilityButtonFunction(chosenMapInt));
+    // Hide special-ability button by default
+    specialAbilityButton.hide();
 }
 
 // Shows or hides the special ability buttons depending on the input.

--- a/src/setup/towerSetup.js
+++ b/src/setup/towerSetup.js
@@ -86,11 +86,6 @@ function towerButtonsSetup() {
     displayRangeButon.position(1640, 780);
     displayRangeButon.class("towerRangeSpecialAbility");
     displayRangeButon.mousePressed(displayRangeButtonFunction);
-
-    // Hide tower & helper buttons by default
-    towerButtonDisplay(false);
-    placeCancelButtonDisplay(false);
-    displayRangeButtonDisplay(false);
 }
 
 // Place's a tower at the x and y the user clicks.

--- a/src/setup/towerSetup.js
+++ b/src/setup/towerSetup.js
@@ -86,6 +86,10 @@ function towerButtonsSetup() {
     displayRangeButon.position(1640, 780);
     displayRangeButon.class("towerRangeSpecialAbility");
     displayRangeButon.mousePressed(displayRangeButtonFunction);
+
+    towerButtonDisplay(false);
+    placeCancelButtonDisplay(false);
+    displayRangeButtonDisplay(false);
 }
 
 // Place's a tower at the x and y the user clicks.

--- a/src/setup/towerSetup.js
+++ b/src/setup/towerSetup.js
@@ -86,6 +86,11 @@ function towerButtonsSetup() {
     displayRangeButon.position(1640, 780);
     displayRangeButon.class("towerRangeSpecialAbility");
     displayRangeButon.mousePressed(displayRangeButtonFunction);
+
+    // Hide tower & helper buttons by default
+    towerButtonDisplay(false);
+    placeCancelButtonDisplay(false);
+    displayRangeButtonDisplay(false);
 }
 
 // Place's a tower at the x and y the user clicks.

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -21,6 +21,8 @@ function setup() {
   specialAbilityButtonSetup();
   // Hide all game DOM elements immediately after creation to prevent UI overlap in AUTH_STATE
   if (typeof hideAllGameDOM === "function") hideAllGameDOM();
+  // Immediately display login UI so it’s visible before first draw()
+  if (typeof showAuthUI === "function") showAuthUI();
 }
 
 // Draw function from the p5.js library. This function runs 60 times per second and is used for animation (i.e. updating object positions, drawing map, etc.).

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -19,9 +19,7 @@ function setup() {
   skillTreeButtonsSetup();
   campaignButtonsSetup();
   specialAbilityButtonSetup();
-  // Hide all game DOM elements immediately after creation to prevent UI overlap in AUTH_STATE
-  if (typeof hideAllGameDOM === "function") hideAllGameDOM();
-}
+  }
 
 // Draw function from the p5.js library. This function runs 60 times per second and is used for animation (i.e. updating object positions, drawing map, etc.).
 function draw() {

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -19,6 +19,8 @@ function setup() {
   skillTreeButtonsSetup();
   campaignButtonsSetup();
   specialAbilityButtonSetup();
+  // Hide all game DOM elements immediately after creation to prevent UI overlap in AUTH_STATE
+  if (typeof hideAllGameDOM === "function") hideAllGameDOM();
 }
 
 // Draw function from the p5.js library. This function runs 60 times per second and is used for animation (i.e. updating object positions, drawing map, etc.).

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -21,8 +21,6 @@ function setup() {
   specialAbilityButtonSetup();
   // Hide all game DOM elements immediately after creation to prevent UI overlap in AUTH_STATE
   if (typeof hideAllGameDOM === "function") hideAllGameDOM();
-  // Immediately display login UI so it’s visible before first draw()
-  if (typeof showAuthUI === "function") showAuthUI();
 }
 
 // Draw function from the p5.js library. This function runs 60 times per second and is used for animation (i.e. updating object positions, drawing map, etc.).


### PR DESCRIPTION
This pull request addresses a major issue with the login screen where all game buttons were appearing on top of each other, preventing users from logging in. The changes made in `src/sketch.js` introduce a call to the `hideAllGameDOM` function immediately after setting up game elements. This ensures that the game UI is hidden at the appropriate time, preventing any overlap while in the AUTH_STATE.

---

> This pull request was co-created with Cosine Genie

Original Task: [tower-defence-cosine/0a2a3attn7b9](https://cosine.sh/5wdpuhj5zgn0/tower-defence-cosine/task/0a2a3attn7b9)
Author: James
