### PR TITLE
Improve Game Over and Menu Confirmation Popups

### DIFF
--- a/src/setup/gameSetup.js
+++ b/src/setup/gameSetup.js
@@ -382,7 +382,7 @@ function checkBaseHealth() {
     airstrikeCheck = false;
     airstrikeCheckCoordCheck = false;
     campaignCheck = false;
-    let tempText = "The game is over. Your score was " + playerScore.toString() + ". Press 'Ok' to restart or press 'Cancel' to return to the menu and/or select another map.";
+    let tempText = "Game over! Your final score was " + playerScore.toString() + ".\n\nPress 'OK' to play again or 'Cancel' to return to the main menu and choose another map.";
     playerBattleMedals += Math.floor(playerScore / 50000);
     if (typeof saveCurrentUserData === "function") saveCurrentUserData();
     playerScore = 0;

--- a/src/setup/menuSetup.js
+++ b/src/setup/menuSetup.js
@@ -86,7 +86,7 @@ function returnToMenuButtonFunction() {
     // Save user data on menu return
     if (typeof saveCurrentUserData === "function") saveCurrentUserData();
 
-    if ((gameState == 2 || gameState == 3 || gameState == 4) && confirm("Are you sure you want to return to menu?")) {
+    if ((gameState == 2 || gameState == 3 || gameState == 4) && confirm("Return to the main menu? Any current progress in this battle will be lost.")) {
         enemyClear();
         chosenMap = [ 
             [0,0,0,0,0,0,0,0,0],


### PR DESCRIPTION
This pull request enhances the user experience by updating the text in the game over popup and the menu return confirmation dialog. 

1. The game over message now reads: "Game over! Your final score was [score]. Press 'OK' to play again or 'Cancel' to return to the main menu and choose another map." This message is clearer and more welcoming.
2. Updated the confirmation message for returning to the menu to state: "Return to the main menu? Any current progress in this battle will be lost." This change provides better context to the player about the consequences of their decision. 

These changes aim to make the game's popups more user-friendly and informative.

---

> This pull request was co-created with Cosine Genie

Original Task: [tower-defence-cosine/215sgjytblgb](https://cosine.sh/5wdpuhj5zgn0/tower-defence-cosine/task/215sgjytblgb)
Author: James
