### PR TITLE
Add Build Phase and Start Game Button in Arcade Mode

### DIFF
--- a/src/setup/authSetup.js
+++ b/src/setup/authSetup.js
@@ -324,6 +324,9 @@ function hideAllGameDOM() {
     if (typeof campaignButtonsDisplay === "function") campaignButtonsDisplay(false);
     if (typeof specialAbilityButtonDisplay === "function") specialAbilityButtonDisplay(false);
     if (window.logoutButton && typeof window.logoutButton.hide === "function") window.logoutButton.hide();
+
+    // Hide Arcade Start Game button if present
+    if (typeof startGameButtonDisplay === "function") startGameButtonDisplay(false);
 }
 
 // Handle login/register

--- a/src/setup/menuSetup.js
+++ b/src/setup/menuSetup.js
@@ -142,6 +142,12 @@ function returnToMenuButtonFunction() {
         if (typeof saveCurrentUserData === "function") saveCurrentUserData();
         playerScore = 0;
         playerCash = 500;
+
+        // --- Arcade Build Phase reset ---
+        if (typeof arcadeStarted !== "undefined") arcadeStarted = false;
+        if (typeof arcadeInfoShown !== "undefined") arcadeInfoShown = false;
+        if (typeof startGameButtonDisplay === "function") startGameButtonDisplay(false);
+
         gameState = 1;
     } else if (gameState == 5 || gameState == 6) {
         if (typeof saveCurrentUserData === "function") saveCurrentUserData();

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -11,6 +11,35 @@ function preload() {
 }
 
 // Setup function from the p5.js library. This function is run once at the start of the program and never again, so it is used for creating the canvas, etc.
+let arcadeStarted = false;      // false = Build Phase, true = active gameplay
+let arcadeInfoShown = false;    // ensures we only show the dialog once per run
+let startGameButton = null;
+
+// Helper: Show/hide Start Game button
+function startGameButtonDisplay(show) {
+  if (startGameButton) {
+    if (show) {
+      startGameButton.show();
+    } else {
+      startGameButton.hide();
+    }
+  }
+}
+
+// Helper: Called when Start Game button is pressed
+function startArcadeGame() {
+  arcadeStarted = true;
+  startGameButtonDisplay(false);
+  // Force each enemyQueue's timeElapsed so next spawn() immediately enqueues an enemy
+  if (typeof enemies !== "undefined" && Array.isArray(enemies)) {
+    for (let i = 0; i < enemies.length; i++) {
+      if (typeof enemies[i].spawnRate !== "undefined") {
+        enemies[i].timeElapsed = enemies[i].spawnRate + 1;
+      }
+    }
+  }
+}
+
 function setup() {
   createCanvas(1856, 864);
   menuButtonsSetup();
@@ -19,6 +48,13 @@ function setup() {
   skillTreeButtonsSetup();
   campaignButtonsSetup();
   specialAbilityButtonSetup();
+
+  // Create Start Game button for Arcade Build Phase
+  startGameButton = createButton('Start Game');
+  startGameButton.position(860, 780);  // Centered at bottom
+  startGameButton.class('mainMenuButtonClass');
+  startGameButton.mousePressed(startArcadeGame);
+  startGameButton.hide();
 }
 
 // Draw function from the p5.js library. This function runs 60 times per second and is used for animation (i.e. updating object positions, drawing map, etc.).
@@ -92,7 +128,8 @@ function draw() {
         mainMenuButtonsDisplay(false);
         returnToMenuButtonDisplay(true);
         setBaseHealth(1000);
-      } else{
+        startGameButtonDisplay(false);
+      } else {
         specialAbilityButton.html(returnSpecialAbilityName());
         mapButtonsDisplay(false);
         mainMenuButtonsDisplay(false);
@@ -105,15 +142,30 @@ function draw() {
         checkBaseHealth();
         displayBaseHealth(baseHealth, baseHealthMax);
         placeTowerFunction();
-        enemySpawn();
-        enemyUpdate();
-        towerUpdate();
-        specialForcesUpdate();
-        enemySetup(1);
-        showSpecialForces();
-        showAirstrike();
-        showTrap();
-        trapFunction();
+
+        // Arcade Build Phase logic
+        if (!arcadeStarted) {
+          // Show info dialog once per run
+          if (!arcadeInfoShown) {
+            if (typeof showGameDialog === "function") {
+              showGameDialog('Build Phase', 'You have time to place your initial towers. Press Start Game when you\'re ready.', 'info');
+            }
+            arcadeInfoShown = true;
+          }
+          startGameButtonDisplay(true);
+          // NO enemySpawn, enemyUpdate, specialForcesUpdate, etc. in Build Phase!
+        } else {
+          startGameButtonDisplay(false);
+          enemySpawn();
+          enemyUpdate();
+          towerUpdate();
+          specialForcesUpdate();
+          enemySetup(1);
+          showSpecialForces();
+          showAirstrike();
+          showTrap();
+          trapFunction();
+        }
       }
       break;
 

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -30,13 +30,10 @@ function startGameButtonDisplay(show) {
 function startArcadeGame() {
   arcadeStarted = true;
   startGameButtonDisplay(false);
-  // Force each enemyQueue's timeElapsed so next spawn() immediately enqueues an enemy
-  if (typeof enemies !== "undefined" && Array.isArray(enemies)) {
-    for (let i = 0; i < enemies.length; i++) {
-      if (typeof enemies[i].spawnRate !== "undefined") {
-        enemies[i].timeElapsed = enemies[i].spawnRate + 1;
-      }
-    }
+  // Enqueue one basic enemy instantly, leave other spawn timers untouched
+  if (typeof enemies !== 'undefined' && enemies[0]) {
+    enemies[0].checkType();   // enqueue one basic soldier
+    enemies[0].timeElapsed = 0; // reset its timer so next spawn waits full period
   }
 }
 
@@ -142,6 +139,7 @@ function draw() {
         checkBaseHealth();
         displayBaseHealth(baseHealth, baseHealthMax);
         placeTowerFunction();
+        towerUpdate(); // Always call, so towers are visible in both phases
 
         // Arcade Build Phase logic
         if (!arcadeStarted) {
@@ -158,7 +156,6 @@ function draw() {
           startGameButtonDisplay(false);
           enemySpawn();
           enemyUpdate();
-          towerUpdate();
           specialForcesUpdate();
           enemySetup(1);
           showSpecialForces();


### PR DESCRIPTION
This PR implements a new 'Build Phase' in the arcade gamemode, allowing players to place towers before the game starts. Users are given an information dialog explaining the build phase and can start the game by pressing a 'Start Game' button. Additionally, the first enemy will spawn sooner once the game starts. Changes include modifications to the game setup files to manage game states and button displays.

---

> This pull request was co-created with Cosine Genie

Original Task: [tower-defence-cosine/jejrqcotvw3u](https://cosine.sh/5wdpuhj5zgn0/tower-defence-cosine/task/jejrqcotvw3u)
Author: James
