### PR TITLE
Move Login Screen to Main Menu

### DIFF
--- a/src/setup/authSetup.js
+++ b/src/setup/authSetup.js
@@ -211,6 +211,7 @@ function showAuthUI() {
         const btnW = 150, btnH = 40;   // match logout button
         const inputW = 150, inputH = 35;
         const gap = 24;          // consistent vertical gap
+        const initialOffset = inputH + gap;  // ensures banner->Username gap equals other gaps
 
         // Message
         authFormElements.message = createDiv("Login or make an account to save progress");
@@ -226,9 +227,7 @@ function showAuthUI() {
         authFormElements.message.style('font-family', 'inherit');
         authFormElements.message.style('pointer-events', 'none'); // allow clicks to pass through
 
-        // Compute message element height and use it to offset y for inputs
-        const messageHeight = authFormElements.message.elt.offsetHeight || 0;
-        let y = widgetY + messageHeight + gap;
+        let y = widgetY + initialOffset;
 
         // Username input
         authFormElements.usernameInput = createInput('');

--- a/src/setup/authSetup.js
+++ b/src/setup/authSetup.js
@@ -272,6 +272,16 @@ function showAuthUI() {
                 switchAuthMode("register");
             });
         } else if (authMode === "register") {
+            // Confirm password input (above Register/Back buttons)
+            authFormElements.confirmPasswordInput = createInput('', 'password');
+            authFormElements.confirmPasswordInput.position(widgetX, y);
+            authFormElements.confirmPasswordInput.attribute("placeholder", "Repeat Password");
+            authFormElements.confirmPasswordInput.class("authInputClass");
+            authFormElements.confirmPasswordInput.size(inputW, inputH);
+            authFormElements.confirmPasswordInput.style('z-index','10');
+
+            y += inputH + gap;
+
             // Register submit button
             authFormElements.registerSubmitBtn = createButton('Register');
             authFormElements.registerSubmitBtn.position(widgetX, y);
@@ -283,16 +293,6 @@ function showAuthUI() {
             });
 
             y += btnH + gap;
-
-            // Confirm password input
-            authFormElements.confirmPasswordInput = createInput('', 'password');
-            authFormElements.confirmPasswordInput.position(widgetX, y);
-            authFormElements.confirmPasswordInput.attribute("placeholder", "Repeat Password");
-            authFormElements.confirmPasswordInput.class("authInputClass");
-            authFormElements.confirmPasswordInput.size(inputW, inputH);
-            authFormElements.confirmPasswordInput.style('z-index','10');
-
-            y += inputH + gap;
 
             // Back to Login button
             authFormElements.backBtn = createButton('Back to Login');
@@ -311,7 +311,7 @@ function showAuthUI() {
         // Track mode for UI reuse checks
         authFormElements.mode = authMode;
         authFormElements.form = true;
-        authFormElements.compact = true;  // identify as compact variant
+        authFormElements.compact = true;
         return;
     }
 

--- a/src/setup/authSetup.js
+++ b/src/setup/authSetup.js
@@ -211,7 +211,8 @@ function showAuthUI() {
         const btnW = 150, btnH = 40;   // match logout button
         const inputW = 150, inputH = 35;
         const gap = 24;          // consistent vertical gap
-        const initialOffset = inputH + gap;  // ensures banner->Username gap equals other gaps
+        const bannerHeight = 32; // approximate height of message div
+        const yStart = bannerHeight + gap;
 
         // Message
         authFormElements.message = createDiv("Login or make an account to save progress");
@@ -227,7 +228,7 @@ function showAuthUI() {
         authFormElements.message.style('font-family', 'inherit');
         authFormElements.message.style('pointer-events', 'none'); // allow clicks to pass through
 
-        let y = widgetY + initialOffset;
+        let y = widgetX + yStart;
 
         // Username input
         authFormElements.usernameInput = createInput('');

--- a/src/setup/authSetup.js
+++ b/src/setup/authSetup.js
@@ -196,9 +196,9 @@ function showAuthUI() {
 
         // Widget X/Y follows logout button (X=40, Y=15 for top edge, 22 for button alignment)
         const widgetX = 40, widgetY = 15;
-        const inputW = 180, inputH = 30;
-        const btnW = 120, btnH = 35;
-        const gap = 8;
+        const btnW = 150, btnH = 40;   // match logout button
+        const inputW = 150, inputH = 35;
+        const gap = 12;
 
         // Message
         authFormElements.message = createDiv("Login or make an account to save progress");
@@ -210,15 +210,17 @@ function showAuthUI() {
         authFormElements.message.style('border-radius', '8px 8px 4px 4px');
         authFormElements.message.style('max-width', '260px');
         authFormElements.message.style('box-shadow', '0 2px 8px rgba(0,0,0,0.07)');
-        authFormElements.message.style('z-index', '1002');
+        authFormElements.message.style('z-index', '1000'); // lower than inputs/buttons
         authFormElements.message.style('font-family', 'inherit');
+        authFormElements.message.style('pointer-events', 'none'); // allow clicks to pass through
 
-        let y = widgetY + 32; // below message
+        let y = widgetY + 50; // add more vertical space below message
 
         // Username input
         authFormElements.usernameInput = createInput('');
         authFormElements.usernameInput.position(widgetX, y);
         authFormElements.usernameInput.attribute("placeholder", "Username");
+        authFormElements.usernameInput.class("authInputClass");
         authFormElements.usernameInput.size(inputW, inputH);
 
         y += inputH + gap;
@@ -227,6 +229,7 @@ function showAuthUI() {
         authFormElements.passwordInput = createInput('', 'password');
         authFormElements.passwordInput.position(widgetX, y);
         authFormElements.passwordInput.attribute("placeholder", "Password");
+        authFormElements.passwordInput.class("authInputClass");
         authFormElements.passwordInput.size(inputW, inputH);
 
         y += inputH + gap;
@@ -236,16 +239,18 @@ function showAuthUI() {
             authFormElements.loginBtn = createButton('Login');
             authFormElements.loginBtn.position(widgetX, y);
             authFormElements.loginBtn.size(btnW, btnH);
+            authFormElements.loginBtn.class("logoutButtonClass");
             authFormElements.loginBtn.mousePressed(function() {
                 handleAuthSubmit("login");
             });
 
-            y += btnH + 2;
+            y += btnH + gap;
 
             // Register button (switches to register mode)
             authFormElements.registerBtn = createButton('Register');
             authFormElements.registerBtn.position(widgetX, y);
             authFormElements.registerBtn.size(btnW, btnH);
+            authFormElements.registerBtn.class("logoutButtonClass");
             authFormElements.registerBtn.mousePressed(function() {
                 switchAuthMode("register");
             });
@@ -254,16 +259,18 @@ function showAuthUI() {
             authFormElements.registerSubmitBtn = createButton('Register');
             authFormElements.registerSubmitBtn.position(widgetX, y);
             authFormElements.registerSubmitBtn.size(btnW, btnH);
+            authFormElements.registerSubmitBtn.class("logoutButtonClass");
             authFormElements.registerSubmitBtn.mousePressed(function() {
                 handleAuthSubmit("register");
             });
 
-            y += btnH + 2;
+            y += btnH + gap;
 
             // Confirm password input
             authFormElements.confirmPasswordInput = createInput('', 'password');
             authFormElements.confirmPasswordInput.position(widgetX, y);
             authFormElements.confirmPasswordInput.attribute("placeholder", "Repeat Password");
+            authFormElements.confirmPasswordInput.class("authInputClass");
             authFormElements.confirmPasswordInput.size(inputW, inputH);
 
             y += inputH + gap;
@@ -272,9 +279,20 @@ function showAuthUI() {
             authFormElements.backBtn = createButton('Back to Login');
             authFormElements.backBtn.position(widgetX, y);
             authFormElements.backBtn.size(btnW, btnH);
+            authFormElements.backBtn.class("logoutButtonClass");
             authFormElements.backBtn.mousePressed(function() {
                 switchAuthMode("login");
             });
+
+            // Attach password requirements popup ONLY to this field
+            authFormElements.passwordInput.elt.addEventListener('focus', showPasswordRequirements);
+        }
+
+        // Track mode for UI reuse checks
+        authFormElements.mode = authMode;
+        authFormElements.form = true;
+        return;
+    });
 
             // Attach password requirements popup ONLY to this field
             authFormElements.passwordInput.elt.addEventListener('focus', showPasswordRequirements);

--- a/src/setup/authSetup.js
+++ b/src/setup/authSetup.js
@@ -186,6 +186,107 @@ function switchAuthMode(mode) {
 
 // Auth UI creation/destroy logic
 function showAuthUI() {
+    const inMenu = (typeof gameState !== 'undefined' && gameState === 1);
+
+    // If we're in the main menu, show compact widget in top-left
+    if (inMenu) {
+        // Don't hide game DOM, only hide old auth widget if any
+        hideAuthUI();
+        authFormElements = {};
+
+        // Widget X/Y follows logout button (X=40, Y=15 for top edge, 22 for button alignment)
+        const widgetX = 40, widgetY = 15;
+        const inputW = 180, inputH = 30;
+        const btnW = 120, btnH = 35;
+        const gap = 8;
+
+        // Message
+        authFormElements.message = createDiv("Login or make an account to save progress");
+        authFormElements.message.position(widgetX, widgetY);
+        authFormElements.message.style('font-size', '16px');
+        authFormElements.message.style('color', '#222');
+        authFormElements.message.style('background', 'rgba(255,255,255,0.92)');
+        authFormElements.message.style('padding', '3px 12px 3px 8px');
+        authFormElements.message.style('border-radius', '8px 8px 4px 4px');
+        authFormElements.message.style('max-width', '260px');
+        authFormElements.message.style('box-shadow', '0 2px 8px rgba(0,0,0,0.07)');
+        authFormElements.message.style('z-index', '1002');
+        authFormElements.message.style('font-family', 'inherit');
+
+        let y = widgetY + 32; // below message
+
+        // Username input
+        authFormElements.usernameInput = createInput('');
+        authFormElements.usernameInput.position(widgetX, y);
+        authFormElements.usernameInput.attribute("placeholder", "Username");
+        authFormElements.usernameInput.size(inputW, inputH);
+
+        y += inputH + gap;
+
+        // Password input
+        authFormElements.passwordInput = createInput('', 'password');
+        authFormElements.passwordInput.position(widgetX, y);
+        authFormElements.passwordInput.attribute("placeholder", "Password");
+        authFormElements.passwordInput.size(inputW, inputH);
+
+        y += inputH + gap;
+
+        if (authMode === "login") {
+            // Login button
+            authFormElements.loginBtn = createButton('Login');
+            authFormElements.loginBtn.position(widgetX, y);
+            authFormElements.loginBtn.size(btnW, btnH);
+            authFormElements.loginBtn.mousePressed(function() {
+                handleAuthSubmit("login");
+            });
+
+            y += btnH + 2;
+
+            // Register button (switches to register mode)
+            authFormElements.registerBtn = createButton('Register');
+            authFormElements.registerBtn.position(widgetX, y);
+            authFormElements.registerBtn.size(btnW, btnH);
+            authFormElements.registerBtn.mousePressed(function() {
+                switchAuthMode("register");
+            });
+        } else if (authMode === "register") {
+            // Register submit button
+            authFormElements.registerSubmitBtn = createButton('Register');
+            authFormElements.registerSubmitBtn.position(widgetX, y);
+            authFormElements.registerSubmitBtn.size(btnW, btnH);
+            authFormElements.registerSubmitBtn.mousePressed(function() {
+                handleAuthSubmit("register");
+            });
+
+            y += btnH + 2;
+
+            // Confirm password input
+            authFormElements.confirmPasswordInput = createInput('', 'password');
+            authFormElements.confirmPasswordInput.position(widgetX, y);
+            authFormElements.confirmPasswordInput.attribute("placeholder", "Repeat Password");
+            authFormElements.confirmPasswordInput.size(inputW, inputH);
+
+            y += inputH + gap;
+
+            // Back to Login button
+            authFormElements.backBtn = createButton('Back to Login');
+            authFormElements.backBtn.position(widgetX, y);
+            authFormElements.backBtn.size(btnW, btnH);
+            authFormElements.backBtn.mousePressed(function() {
+                switchAuthMode("login");
+            });
+
+            // Attach password requirements popup ONLY to this field
+            authFormElements.passwordInput.elt.addEventListener('focus', showPasswordRequirements);
+        }
+
+        // Track mode for UI reuse checks
+        authFormElements.mode = authMode;
+        authFormElements.form = true;
+        return;
+    }
+
+    // --- ELSE: not in main menu, keep existing behavior ---
     hideAllGameDOM();
 
     // If form for this mode is already displayed, just show and return
@@ -204,12 +305,10 @@ function showAuthUI() {
     hideAuthUI();
     authFormElements = {};
 
-    // Center the form on canvas
+    // --- Fullscreen (centered) auth UI ---
     let centerX = 928, centerY = 432, formWidth = 330;
 
     if (authMode === "login") {
-        // LOGIN FORM
-
         // Username input
         authFormElements.usernameInput = createInput('');
         authFormElements.usernameInput.position(centerX - 160, centerY - 150);
@@ -217,7 +316,7 @@ function showAuthUI() {
         authFormElements.usernameInput.class("authInputClass");
         authFormElements.usernameInput.size(320, 50);
 
-        // Password input (NO password requirements popup)
+        // Password input
         authFormElements.passwordInput = createInput('', 'password');
         authFormElements.passwordInput.position(centerX - 160, centerY - 60);
         authFormElements.passwordInput.attribute("placeholder", "Password");
@@ -233,7 +332,7 @@ function showAuthUI() {
             handleAuthSubmit("login");
         });
 
-        // Register button (switches to register mode)
+        // Register button
         authFormElements.registerBtn = createButton('Register');
         authFormElements.registerBtn.position(centerX - 100, centerY + 110);
         authFormElements.registerBtn.class("authButtonClass");
@@ -243,8 +342,6 @@ function showAuthUI() {
         });
 
     } else if (authMode === "register") {
-        // REGISTER FORM
-
         // Username input
         authFormElements.usernameInput = createInput('');
         authFormElements.usernameInput.position(centerX - 160, centerY - 200);
@@ -252,7 +349,7 @@ function showAuthUI() {
         authFormElements.usernameInput.class("authInputClass");
         authFormElements.usernameInput.size(320, 50);
 
-        // Password input (pw1)
+        // Password input
         authFormElements.passwordInput = createInput('', 'password');
         authFormElements.passwordInput.position(centerX - 160, centerY - 120);
         authFormElements.passwordInput.attribute("placeholder", "Password");
@@ -262,7 +359,7 @@ function showAuthUI() {
         // Attach password requirements popup ONLY to this field
         authFormElements.passwordInput.elt.addEventListener('focus', showPasswordRequirements);
 
-        // Confirm password input (pw2)
+        // Confirm password input
         authFormElements.confirmPasswordInput = createInput('', 'password');
         authFormElements.confirmPasswordInput.position(centerX - 160, centerY - 40);
         authFormElements.confirmPasswordInput.attribute("placeholder", "Repeat Password");
@@ -408,8 +505,8 @@ function showLogoutButton() {
             saveCurrentUserData();
             currentUser = null;
             currentUserData = null;
-            gameState = 0;
-            showAuthUI();
+            gameState = 1; // Go back to main menu after logout
+            showAuthUI();  // Show compact auth widget in menu
         });
     }
     window.logoutButton.show();

--- a/src/setup/authSetup.js
+++ b/src/setup/authSetup.js
@@ -210,8 +210,7 @@ function showAuthUI() {
         const widgetX = 40, widgetY = 15;
         const btnW = 150, btnH = 40;   // match logout button
         const inputW = 150, inputH = 35;
-        const startOffset = 70;  // more space below message
-        const gap = 24;          // even more vertical gap
+        const gap = 24;          // consistent vertical gap
 
         // Message
         authFormElements.message = createDiv("Login or make an account to save progress");
@@ -227,7 +226,9 @@ function showAuthUI() {
         authFormElements.message.style('font-family', 'inherit');
         authFormElements.message.style('pointer-events', 'none'); // allow clicks to pass through
 
-        let y = widgetY + startOffset; // more vertical space below message
+        // Compute message element height and use it to offset y for inputs
+        const messageHeight = authFormElements.message.elt.offsetHeight || 0;
+        let y = widgetY + messageHeight + gap;
 
         // Username input
         authFormElements.usernameInput = createInput('');

--- a/src/setup/authSetup.js
+++ b/src/setup/authSetup.js
@@ -189,8 +189,20 @@ function showAuthUI() {
     const inMenu = (typeof gameState !== 'undefined' && gameState === 1);
 
     // If we're in the main menu, show compact widget in top-left
+    // --- Main-menu compact auth widget ---
     if (inMenu) {
-        // Don't hide game DOM, only hide old auth widget if any
+        // If the compact form for this mode is already present, just show & exit
+        if (authFormElements.form && authFormElements.compact && authFormElements.mode === authMode) {
+            for (let k in authFormElements) {
+                if (authFormElements[k] && typeof authFormElements[k].show === 'function') {
+                    authFormElements[k].show();
+                } else if (authFormElements[k] && authFormElements[k].style) {
+                    authFormElements[k].style.display = 'block';
+                }
+            }
+            return;
+        }
+        // Rebuild widget (first time or mode change)
         hideAuthUI();
         authFormElements = {};
 
@@ -199,7 +211,7 @@ function showAuthUI() {
         const btnW = 150, btnH = 40;   // match logout button
         const inputW = 150, inputH = 35;
         const startOffset = 70;  // more space below message
-        const gap = 18;          // more vertical gap
+        const gap = 24;          // even more vertical gap
 
         // Message
         authFormElements.message = createDiv("Login or make an account to save progress");
@@ -299,6 +311,7 @@ function showAuthUI() {
         // Track mode for UI reuse checks
         authFormElements.mode = authMode;
         authFormElements.form = true;
+        authFormElements.compact = true;  // identify as compact variant
         return;
     }
 

--- a/src/setup/authSetup.js
+++ b/src/setup/authSetup.js
@@ -198,7 +198,8 @@ function showAuthUI() {
         const widgetX = 40, widgetY = 15;
         const btnW = 150, btnH = 40;   // match logout button
         const inputW = 150, inputH = 35;
-        const gap = 12;
+        const startOffset = 70;  // more space below message
+        const gap = 18;          // more vertical gap
 
         // Message
         authFormElements.message = createDiv("Login or make an account to save progress");
@@ -210,11 +211,11 @@ function showAuthUI() {
         authFormElements.message.style('border-radius', '8px 8px 4px 4px');
         authFormElements.message.style('max-width', '260px');
         authFormElements.message.style('box-shadow', '0 2px 8px rgba(0,0,0,0.07)');
-        authFormElements.message.style('z-index', '1000'); // lower than inputs/buttons
+        authFormElements.message.style('z-index', '5'); // lower than inputs/buttons
         authFormElements.message.style('font-family', 'inherit');
         authFormElements.message.style('pointer-events', 'none'); // allow clicks to pass through
 
-        let y = widgetY + 50; // add more vertical space below message
+        let y = widgetY + startOffset; // more vertical space below message
 
         // Username input
         authFormElements.usernameInput = createInput('');
@@ -222,6 +223,7 @@ function showAuthUI() {
         authFormElements.usernameInput.attribute("placeholder", "Username");
         authFormElements.usernameInput.class("authInputClass");
         authFormElements.usernameInput.size(inputW, inputH);
+        authFormElements.usernameInput.style('z-index','10');
 
         y += inputH + gap;
 
@@ -231,6 +233,7 @@ function showAuthUI() {
         authFormElements.passwordInput.attribute("placeholder", "Password");
         authFormElements.passwordInput.class("authInputClass");
         authFormElements.passwordInput.size(inputW, inputH);
+        authFormElements.passwordInput.style('z-index','10');
 
         y += inputH + gap;
 
@@ -240,6 +243,7 @@ function showAuthUI() {
             authFormElements.loginBtn.position(widgetX, y);
             authFormElements.loginBtn.size(btnW, btnH);
             authFormElements.loginBtn.class("logoutButtonClass");
+            authFormElements.loginBtn.style('z-index','10');
             authFormElements.loginBtn.mousePressed(function() {
                 handleAuthSubmit("login");
             });
@@ -251,6 +255,7 @@ function showAuthUI() {
             authFormElements.registerBtn.position(widgetX, y);
             authFormElements.registerBtn.size(btnW, btnH);
             authFormElements.registerBtn.class("logoutButtonClass");
+            authFormElements.registerBtn.style('z-index','10');
             authFormElements.registerBtn.mousePressed(function() {
                 switchAuthMode("register");
             });
@@ -260,6 +265,7 @@ function showAuthUI() {
             authFormElements.registerSubmitBtn.position(widgetX, y);
             authFormElements.registerSubmitBtn.size(btnW, btnH);
             authFormElements.registerSubmitBtn.class("logoutButtonClass");
+            authFormElements.registerSubmitBtn.style('z-index','10');
             authFormElements.registerSubmitBtn.mousePressed(function() {
                 handleAuthSubmit("register");
             });
@@ -272,6 +278,7 @@ function showAuthUI() {
             authFormElements.confirmPasswordInput.attribute("placeholder", "Repeat Password");
             authFormElements.confirmPasswordInput.class("authInputClass");
             authFormElements.confirmPasswordInput.size(inputW, inputH);
+            authFormElements.confirmPasswordInput.style('z-index','10');
 
             y += inputH + gap;
 
@@ -280,6 +287,7 @@ function showAuthUI() {
             authFormElements.backBtn.position(widgetX, y);
             authFormElements.backBtn.size(btnW, btnH);
             authFormElements.backBtn.class("logoutButtonClass");
+            authFormElements.backBtn.style('z-index','10');
             authFormElements.backBtn.mousePressed(function() {
                 switchAuthMode("login");
             });

--- a/src/setup/authSetup.js
+++ b/src/setup/authSetup.js
@@ -292,16 +292,6 @@ function showAuthUI() {
         authFormElements.mode = authMode;
         authFormElements.form = true;
         return;
-    });
-
-            // Attach password requirements popup ONLY to this field
-            authFormElements.passwordInput.elt.addEventListener('focus', showPasswordRequirements);
-        }
-
-        // Track mode for UI reuse checks
-        authFormElements.mode = authMode;
-        authFormElements.form = true;
-        return;
     }
 
     // --- ELSE: not in main menu, keep existing behavior ---

--- a/src/setup/authSetup.js
+++ b/src/setup/authSetup.js
@@ -228,7 +228,7 @@ function showAuthUI() {
         authFormElements.message.style('font-family', 'inherit');
         authFormElements.message.style('pointer-events', 'none'); // allow clicks to pass through
 
-        let y = widgetX + yStart;
+        let y = widgetY + yStart;
 
         // Username input
         authFormElements.usernameInput = createInput('');

--- a/src/setup/masterSetup.js
+++ b/src/setup/masterSetup.js
@@ -3,7 +3,8 @@
 "use strict";
 
 const AUTH_STATE = 0;
-let gameState = AUTH_STATE;
+// Start directly in the main menu
+let gameState = 1;
 
 let playerScore = 0;
 let playerCash = 500;

--- a/src/sketch.js
+++ b/src/sketch.js
@@ -64,7 +64,6 @@ function draw() {
 
     // Loads the menu.
     case 1:
-      if (typeof hideAuthUI === "function") hideAuthUI();
       titleAndImageSetup();
       mainMenuButtonsDisplay(true);
       mapButtonsDisplay(false);
@@ -75,8 +74,15 @@ function draw() {
       skillTreeButtonsDisplay(false);
       campaignButtonsDisplay(false);
       specialAbilityButtonDisplay(false);
-      // Show logout if user logged in
-      if (typeof showLogoutButton === "function" && currentUser) showLogoutButton();
+
+      // Auth widget logic: show auth widget if not logged in, otherwise show logout
+      if (!currentUser) {
+        if (typeof showAuthUI === "function") showAuthUI();
+        if (typeof hideLogoutButton === "function") hideLogoutButton();
+      } else {
+        if (typeof hideAuthUI === "function") hideAuthUI();
+        if (typeof showLogoutButton === "function") showLogoutButton();
+      }
       break;
 
     // Loads the campaign game mode.


### PR DESCRIPTION
This pull request relocates the login screen to the main menu's top-left corner, replacing the logout button location. A message prompts users to log in or create an account to save their progress. Upon logging in, the login area is replaced by the logout button, which can revert to the login area when pressed. Additionally, if users opt not to log in, a temporary file will store their game progress, ensuring battle medals and relevant user information are saved only during active sessions.

---

> This pull request was co-created with Cosine Genie

Original Task: [tower-defence-cosine/waw0pk6hji8e](https://cosine.sh/5wdpuhj5zgn0/tower-defence-cosine/task/waw0pk6hji8e)
Author: James
